### PR TITLE
Add support for fetching multiple standups for a user

### DIFF
--- a/aws-backend/amplify/backend/function/standupendpoint/standupendpoint-cloudformation-template.json
+++ b/aws-backend/amplify/backend/function/standupendpoint/standupendpoint-cloudformation-template.json
@@ -76,7 +76,7 @@
 				"Timeout": "25",
 				"Code": {
 					"S3Bucket": "amplify-mlhfellowbook-dev-215635-deployment",
-					"S3Key": "amplify-builds/standupendpoint-345246784e304376677a-build.zip"
+					"S3Key": "amplify-builds/standupendpoint-463037616a5262484f59-build.zip"
 				}
 			}
 		},


### PR DESCRIPTION
This adds a `limit` query parameter to the /standups API endpoint, when also using the `user` query parameter, to get multiple standups.

I've also added a `createdAt` field to the returned JSON, which will be useful when showing the standups in the webapp!

Closes #7.