### PR TITLE
Add events web integration

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,7 +1,8 @@
 @import "./primer.css";
 
 .App {
-  /* border: 2px solid; */
+  padding-left: 10px;
+  padding-right: 10px;
 }
 
 .Search {
@@ -58,6 +59,56 @@
 
 .custom-avatar:hover .cta {
   opacity: 1;
+}
+
+.event {
+  display: flex;
+}
+
+a.event {
+  color: initial;
+}
+
+a.event {
+  text-decoration: none;
+}
+
+.event .calendar {
+  box-sizing: border-box;
+  min-width: 85px;
+  min-height: 85px;
+  background-color: lightgrey;
+  text-align: center;
+  border-radius: 5px;
+}
+
+.event .calendar span {
+  display: block;
+}
+
+.event .calendar .day {
+  border-top-right-radius: 5px;
+  border-top-left-radius: 5px;
+  padding: 5px;
+  background-color: red;
+  color: white;
+}
+
+.event .calendar .date {
+  font-size: 30px;
+  margin-top: -5px;
+}
+
+.event .calendar .month {
+  margin-top: -10px;
+}
+
+.event .details {
+  padding-left: 10px;
+}
+
+.event .details span {
+  display: block;
 }
 
 @media screen and (max-width: 900px) {

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -11,12 +11,13 @@ import Events from './Pages/Events';
 import "./App.css";
 import Header from "./Components/Header";
 import "font-awesome/css/font-awesome.min.css";
-import { fetchData } from "./Components";
+import { fetchFellows, fetchEvents } from "./Components";
 
 class App extends React.Component {
   state = {
-    data: [],
+    fellows: [],
     accessToken: null,
+    events: {},
   };
 
   async componentDidMount() {
@@ -30,15 +31,15 @@ class App extends React.Component {
     }
 
     if (accessToken) {
-      const fetchedData = await fetchData(accessToken);
-      console.log(fetchedData);
-      if (!fetchedData || !fetchedData.length) accessToken = null;
-      this.setState({ data: fetchedData, accessToken });
+      const fellows = await fetchFellows(accessToken);
+      const events = await fetchEvents(accessToken);
+      console.log(events, fellows);
+      this.setState({ fellows, accessToken, events });
     }
   }
 
-  setAccessToken = token => this.setState({ accessToken: token });
-  setFetchedFellows = data => this.setState({ data });
+  setAccessToken = accessToken => this.setState({ accessToken });
+  setFetchedFellows = fellows => this.setState({ fellows });
 
   render() {
     return (
@@ -46,28 +47,28 @@ class App extends React.Component {
         <div>
           <Header />
           <Switch>
-            <Route path="/fellows/:username" render={props =>
+            <Route path="/fellows/:username" component={props =>
               <Fellows accessToken={this.state.accessToken} {...props} />
             } />
-            <Route path="/fellows" render={() =>
+            <Route path="/fellows" component={() =>
               <Fellows accessToken={this.state.accessToken} />
             } />
-            <Route path="/events/:id" render={props =>
-              <Events accessToken={this.state.accessToken} {...props} />
+            <Route path="/events/:id" component={props =>
+              <Events accessToken={this.state.accessToken} events={this.state.events} {...props} />
             } />
-            <Route path="/events" render={() =>
-              <Events accessToken={this.state.accessToken} />
+            <Route path="/events" component={() =>
+              <Events accessToken={this.state.accessToken} events={this.state.events} />
             } />
             <Route path="/">
               <Home
                 setAccessToken={this.setAccessToken}
                 setFetchedFellows={this.setFetchedFellows}
-                data={this.state.data}
+                fellows={this.state.fellows}
                 accessToken={this.state.accessToken} />
             </Route>
           </Switch>
         </div>
-      </Router >
+      </Router>
     );
   }
 }

--- a/web/src/Components/Event.js
+++ b/web/src/Components/Event.js
@@ -18,7 +18,7 @@ export default function Event(props) {
 
   const handleClick = (e) => {
     e.preventDefault();
-    history.push(`/events/${props.event.id}`)
+    if (!props.extended) history.push(`/events/${props.event.id}`)
   };
 
   return (
@@ -37,6 +37,9 @@ export default function Event(props) {
         <span className="summary">
           {props.event.summary}
         </span>
+        {props.extended && (
+          <a href={props.event.location}>Join event!</a>
+        )}
       </div>
     </a>
   )

--- a/web/src/Components/Event.js
+++ b/web/src/Components/Event.js
@@ -1,0 +1,43 @@
+import React from "react";
+import { useHistory } from "react-router-dom";
+
+
+const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+const mapDay = n => days[n];
+
+const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
+const mapMonth = n => months[n];
+
+export default function Event(props) {
+  const history = useHistory();
+
+  const d = new Date(props.event.start.dateTime);
+  const day = mapDay(d.getDay());
+  const date = d.getDate();
+  const month = mapMonth(d.getMonth());
+
+  const handleClick = (e) => {
+    e.preventDefault();
+    history.push(`/events/${props.event.id}`)
+  };
+
+  return (
+    <a onClick={handleClick} href={`/events/${props.event.id}`} className="event">
+      <div className="calendar">
+        <span className="day">{day}</span>
+        <span className="date">{date}</span>
+        <span className="month">{month}</span>
+      </div>
+      <div className="details">
+        <span className="times">
+          {new Date(props.event.start.dateTime).toLocaleTimeString()}
+          {' '}-{' '}
+          {new Date(props.event.end.dateTime).toLocaleTimeString()}
+        </span>
+        <span className="summary">
+          {props.event.summary}
+        </span>
+      </div>
+    </a>
+  )
+};

--- a/web/src/Components/Header.jsx
+++ b/web/src/Components/Header.jsx
@@ -31,12 +31,12 @@ export default function PrimarySearchAppBar() {
           />
         </div>
         <div className="Header-item">
-          <a href="#" className="Header-link">
+          <a href="/" className="Header-link">
             Home
           </a>
         </div>
         <div className="Header-item">
-          <a href="#" className="Header-link">
+          <a href="/events" className="Header-link">
             Events
           </a>
         </div>

--- a/web/src/Components/TabPanel.js
+++ b/web/src/Components/TabPanel.js
@@ -1,0 +1,30 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import { Box, Text } from "@primer/components";
+
+export default function TabPanel(props) {
+  const { children, tab, value, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={tab !== value}
+      id={`scrollable-force-tabpanel-${value}`}
+      aria-labelledby={`scrollable-force-tab-${value}`}
+      {...other}
+    >
+      {tab === value && (
+        <Box p={3} as="div">
+          <Text as="div">{children}</Text>
+        </Box>
+      )}
+    </div>
+  );
+}
+
+TabPanel.propTypes = {
+  children: PropTypes.node,
+  tab: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+};

--- a/web/src/Components/index.js
+++ b/web/src/Components/index.js
@@ -1,11 +1,11 @@
 import axios from "axios";
 
 const apiUrl =
-  "https://ld48eii9kk.execute-api.eu-central-1.amazonaws.com/dev/fellows";
+  "https://ld48eii9kk.execute-api.eu-central-1.amazonaws.com/dev";
 
-export const fetchData = async (accessToken) => {
+export const fetchFellows = async (accessToken) => {
   try {
-    const response = await axios.get(apiUrl, {
+    const response = await axios.get(`${apiUrl}/fellows`, {
       headers: {
         Authorization: accessToken,
       },
@@ -17,3 +17,18 @@ export const fetchData = async (accessToken) => {
     return [];
   }
 };
+
+export const fetchEvents = async (accessToken) => {
+  try {
+    const response = await axios.get(`${apiUrl}/events`, {
+      headers: {
+        Authorization: accessToken,
+      },
+    });
+
+    return response.data;
+  } catch (error) {
+    console.log(error);
+    return [];
+  }
+}

--- a/web/src/Pages/Events.js
+++ b/web/src/Pages/Events.js
@@ -1,67 +1,111 @@
 import React from "react";
-import Search from "../Components/Search";
+import { SubNav, TextInput } from "@primer/components";
 
 import Event from "../Components/Event";
+import TabPanel from "../Components/TabPanel";
 
-export default class Events extends React.Component {
-  state = { search: "" };
+import { SearchIcon } from "@primer/octicons-react";
 
-  handleInput = (e) => {
-    this.setState({ search: e.target.value.toLowerCase() });
-  };
+export default function Events(props) {
+  const [tab, setTab] = React.useState("upcoming");
+  const [search, setSearch] = React.useState("");
 
-  createEvents() {
-    return this.props.events.items.filter(e => e.summary && e.start.dateTime).map((event, i) => (
-      <Event event={event} key={i} />
-    ));
-  }
+  const createEvents = () => {
+    const events = props.events.items
+      .filter(e => e.summary && e.start.dateTime)
+      .filter(e => search ? e.summary.toLowerCase().includes(search) : true)
+      .sort((a, b) => new Date(a.end.dateTime) - new Date(b.end.dateTime));
 
-  render() {
-    if (!this.props.events.items) return <div />
-
-    const id = this.props.match && this.props.match.params
-      ? this.props.match.params.id
-      : null;
-
-    if (id) {
-      const event = this.props.events.items.find(e => e.id === id);
-      if (event) {
-        return (
-          <div className="App">
-            <main className="container">
-              Event: {event.summary}
-            </main>
-          </div>
-        );
-      } else {
-        return (
-          <div className="App">
-            <main className="container">
-              <h1>No event found for ID {id}!</h1>
-            </main>
-          </div>
-        );
-      }
-    }
+    const pastEvents = events.filter(e => new Date(e.end.dateTime).getTime() < new Date().getTime());
+    const futureEvents = events.filter(e => new Date(e.end.dateTime).getTime() >= new Date().getTime());
 
     return (
-      <div className="App">
-        <header className="App-header">
-          <div className="Search">
-            <Search handleInput={this.handleInput} />
+      <div>
+        <SubNav aria-label="Main">
+          <SubNav.Links>
+            <SubNav.Link
+              href="#upcoming"
+              selected={tab === "upcoming"}
+              onClick={() => setTab("upcoming")}>
+              Upcoming Events
+          </SubNav.Link>
+            <SubNav.Link
+              href="#past"
+              selected={tab === "past"}
+              onClick={() => setTab("past")}>
+              Past Events
+          </SubNav.Link>
+          </SubNav.Links>
+
+          <TextInput
+            type="search"
+            icon={SearchIcon}
+            width={320}
+            onInput={(e) => setSearch(e.target.value.toLowerCase())} />
+        </SubNav>
+
+        <TabPanel tab={tab} value={"upcoming"}>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "auto auto auto",
+              gridRowGap: "20px",
+            }}
+          >
+            {futureEvents.map((event, i) => (
+              <Event event={event} key={i} />
+            ))}
           </div>
-        </header>
-        <h1>Events</h1>
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "auto auto auto",
-            gridRowGap: "20px",
-          }}
-        >
-          {this.createEvents()}
-        </div>
-      </div>
+        </TabPanel>
+        <TabPanel tab={tab} value={"past"}>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "auto auto auto",
+              gridRowGap: "20px",
+            }}
+          >
+            {pastEvents.map((event, i) => (
+              <Event event={event} key={i} />
+            ))}
+          </div>
+        </TabPanel>
+      </div >
     );
+  };
+
+  if (!props.events.items) return <div />
+
+  const id = props.match && props.match.params
+    ? props.match.params.id
+    : null;
+
+  if (id) {
+    const event = props.events.items.find(e => e.id === id);
+    if (event) {
+      return (
+        <div className="App">
+          <main className="container">
+            Event: {event.summary}
+          </main>
+        </div>
+      );
+    } else {
+      return (
+        <div className="App">
+          <main className="container">
+            <h1>No event found for ID {id}!</h1>
+          </main>
+        </div>
+      );
+    }
   }
+
+  return (
+    <div className="App">
+      <header className="App-header">
+      </header>
+      {createEvents()}
+    </div>
+  );
 }

--- a/web/src/Pages/Events.js
+++ b/web/src/Pages/Events.js
@@ -85,9 +85,8 @@ export default function Events(props) {
     if (event) {
       return (
         <div className="App">
-          <main className="container">
-            Event: {event.summary}
-          </main>
+          <Event event={event} extended />
+          <div className="description" dangerouslySetInnerHTML={{ __html: event.description }} />
         </div>
       );
     } else {
@@ -103,8 +102,6 @@ export default function Events(props) {
 
   return (
     <div className="App">
-      <header className="App-header">
-      </header>
       {createEvents()}
     </div>
   );

--- a/web/src/Pages/Events.js
+++ b/web/src/Pages/Events.js
@@ -1,6 +1,7 @@
 import React from "react";
-import Header from "../Components/Header";
 import Search from "../Components/Search";
+
+import Event from "../Components/Event";
 
 export default class Events extends React.Component {
   state = { search: "" };
@@ -9,16 +10,38 @@ export default class Events extends React.Component {
     this.setState({ search: e.target.value.toLowerCase() });
   };
 
+  createEvents() {
+    return this.props.events.items.filter(e => e.summary && e.start.dateTime).map((event, i) => (
+      <Event event={event} key={i} />
+    ));
+  }
+
   render() {
-    let id;
-    if (this.props.match && this.props.match.params) id = this.props.match.params.id;
+    if (!this.props.events.items) return <div />
+
+    const id = this.props.match && this.props.match.params
+      ? this.props.match.params.id
+      : null;
 
     if (id) {
-      return (
-        <div className="App">
-          <main className="container">Event: {id}</main>
-        </div>
-      );
+      const event = this.props.events.items.find(e => e.id === id);
+      if (event) {
+        return (
+          <div className="App">
+            <main className="container">
+              Event: {event.summary}
+            </main>
+          </div>
+        );
+      } else {
+        return (
+          <div className="App">
+            <main className="container">
+              <h1>No event found for ID {id}!</h1>
+            </main>
+          </div>
+        );
+      }
     }
 
     return (
@@ -28,7 +51,16 @@ export default class Events extends React.Component {
             <Search handleInput={this.handleInput} />
           </div>
         </header>
-        <main className="container">Events</main>
+        <h1>Events</h1>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "auto auto auto",
+            gridRowGap: "20px",
+          }}
+        >
+          {this.createEvents()}
+        </div>
       </div>
     );
   }

--- a/web/src/Pages/Home.jsx
+++ b/web/src/Pages/Home.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { makeStyles } from "@material-ui/core/styles";
 import Profile from "../Components/Profile";
 import SimpleAvatar from "../Components/SimpleAvatar";
@@ -12,36 +11,11 @@ import n8n from "../img/n8n.png";
 import sheetjs from "../img/sheetjs.png";
 import webaverse from "../img/webaverse.ico";
 
-import { TabNav, Box, Text } from "@primer/components";
+import TabPanel from "../Components/TabPanel";
+import { TabNav } from "@primer/components";
 import { NoteIcon, PersonIcon, RepoIcon } from "@primer/octicons-react";
 
 import octocat from "../img/octocat-white.png";
-
-function TabPanel(props) {
-  const { children, tab, value, ...other } = props;
-
-  return (
-    <div
-      role="tabpanel"
-      hidden={tab !== value}
-      id={`scrollable-force-tabpanel-${value}`}
-      aria-labelledby={`scrollable-force-tab-${value}`}
-      {...other}
-    >
-      {tab === value && (
-        <Box p={3} as="div">
-          <Text as="div">{children}</Text>
-        </Box>
-      )}
-    </div>
-  );
-}
-
-TabPanel.propTypes = {
-  children: PropTypes.node,
-  tab: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
-};
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/web/src/Pages/Home.jsx
+++ b/web/src/Pages/Home.jsx
@@ -56,7 +56,7 @@ export default function Home(props) {
   const [tab, setTab] = React.useState("home");
 
   const createAvatars = () =>
-    props.data.map((fellow, i) => (
+    props.fellows.map((fellow, i) => (
       <SimpleAvatar bgPhoto={fellow.avatar_url} cta="View profile" key={i} />
     ));
 


### PR DESCRIPTION
Closes #29.

Adds an events page to the web app!

- `/events` will show the upcoming and past events in on-page tabs and on-page search
- `/events/id` will show the data for each event individually, with the entire description and link to zoom/mlh organise page